### PR TITLE
fix: eliminate example courses + clean up job title before search

### DIFF
--- a/lib/screens/courses/courses.dart
+++ b/lib/screens/courses/courses.dart
@@ -52,7 +52,12 @@ class CoursesRepository {
       AuthService().user?.uid ?? "",
     );
     String prompt =
-        "Provide a list of REAL online courses a student interested in becoming a $job could take, in JSON format. The JSON should be an array of arrays, where each inner array represents a course and contains the following elements in order: Title, Author, Summary description, URL to the course. Do not add any comments";
+        """Provide a list of REAL online courses from reputable educational platforms, that a student interested in becoming a $job could take, in JSON format. 
+        The JSON should be an array of arrays, where each inner array represents a course and contains the following elements in order: 
+        Title, Author or Provider, Summary description, URL to the course.
+        Only provide courses that are verifiable as currently available. 
+        Do not add any comments.""";
+        
     final content = [Content.text(prompt)];
     final response = await model.generateContent(content);
 

--- a/lib/screens/joblistings/joblistings.dart
+++ b/lib/screens/joblistings/joblistings.dart
@@ -101,9 +101,10 @@ class JobListingRepository {
   }
 
   static Future<List<Job>> _fetchJobs() async {
-    final chosenJob = FirestoreService().getChosenJob(
+    final chosenJob = (await FirestoreService().getChosenJob(
       AuthService().user?.uid ?? "",
-    );
+    )).replaceAll(RegExp(r"\(|\/|\)| "), "-"); // Replace parenthesis, slashes and spaces with '-'
+
     final url = Uri.parse('https://www.seek.com.au/$chosenJob-jobs');
     // final url = Uri.parse('https://example.com');
     final response = await http.get(url);
@@ -239,7 +240,8 @@ class LargeJobCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(job.salary),
+                Expanded(child: Text(job.salary, overflow: TextOverflow.ellipsis)),
+                Padding(padding: EdgeInsets.symmetric(horizontal: 8.0)),
                 ElevatedButton(
                   onPressed:
                       () async => await launchUrl(


### PR DESCRIPTION
- Hopefully eliminates example.com courses from gemini.
- Job titles like "UX/UI Designer" will now get cleaned up before fetching job listings.